### PR TITLE
chore: upgrade lib-node-registry to 0.7.0 for cache busting

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,7 @@
     "@data-fair/catalogs-shared": "*",
     "@data-fair/lib-express": "^1.22.5",
     "@data-fair/lib-node": "^2.12.1",
-    "@data-fair/lib-node-registry": "^0.6.0",
+    "@data-fair/lib-node-registry": "^0.7.0",
     "@data-fair/lib-utils": "^1.10.1",
     "config": "^4.4.1",
     "express": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@data-fair/catalogs-shared": "*",
         "@data-fair/lib-express": "^1.22.5",
         "@data-fair/lib-node": "^2.12.1",
-        "@data-fair/lib-node-registry": "^0.6.0",
+        "@data-fair/lib-node-registry": "^0.7.0",
         "@data-fair/lib-utils": "^1.10.1",
         "config": "^4.4.1",
         "express": "^5.2.0",
@@ -573,9 +573,9 @@
       }
     },
     "node_modules/@data-fair/lib-node-registry": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-node-registry/-/lib-node-registry-0.6.0.tgz",
-      "integrity": "sha512-TT3IFJwOwksl6rGi1JIz7tBM0M3NWyDcHR3orsAtF2UGn64cvQti829lfuhTAmGOhWA/nWjWL4kxDYliOKsJNA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-node-registry/-/lib-node-registry-0.7.0.tgz",
+      "integrity": "sha512-BZiIsyBkYOuNkSqkhHJ/E4hQrRkfDwR4W7Q4b33ezRo2MTk9MMni8h8VtBPXI+Ex3A1V504n72KJHaTdNwDoew==",
       "license": "MIT",
       "dependencies": {
         "@types/resolve-path": "^1.4.3",
@@ -11704,7 +11704,7 @@
       "dependencies": {
         "@data-fair/catalogs-shared": "*",
         "@data-fair/lib-node": "^2.12.1",
-        "@data-fair/lib-node-registry": "^0.6.0",
+        "@data-fair/lib-node-registry": "^0.7.0",
         "config": "^4.4.1",
         "debug": "^4.4.1",
         "form-data": "^4.0.4",

--- a/shared/plugin-load.ts
+++ b/shared/plugin-load.ts
@@ -8,12 +8,14 @@ import { readFile, access } from 'node:fs/promises'
  * type-stripping (main: "index.ts"). Callers must not hard-code an extension —
  * read main and trust it. Defaults to "index.js" when main is absent.
  *
- * `cacheBust` appends a query string so the same module path can be re-imported
- * fresh in the same process.
+ * No in-process cache busting is needed: @data-fair/lib-node-registry extracts a
+ * changed artefact into a content-versioned directory, so an updated plugin
+ * always resolves to a brand-new absolute path. That forces Node's ESM registry
+ * to reload the whole module graph (entry + siblings + bundled deps) — something
+ * a `?query` suffix on the entry point could never do.
  */
 export const importPluginModule = async <T = unknown> (
-  pluginDir: string,
-  opts: { cacheBust?: boolean } = {}
+  pluginDir: string
 ): Promise<T> => {
   const pkg = JSON.parse(await readFile(path.join(pluginDir, 'package.json'), 'utf8'))
   const mainRel = typeof pkg.main === 'string' && pkg.main.length > 0 ? pkg.main : 'index.js'
@@ -23,6 +25,5 @@ export const importPluginModule = async <T = unknown> (
   } catch {
     throw new Error(`plugin entry point missing: ${mainAbs}`)
   }
-  const url = opts.cacheBust ? `${mainAbs}?imported=${Date.now()}` : mainAbs
-  return (await import(url)) as T
+  return (await import(mainAbs)) as T
 }

--- a/worker/package.json
+++ b/worker/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@data-fair/catalogs-shared": "*",
     "@data-fair/lib-node": "^2.12.1",
-    "@data-fair/lib-node-registry": "^0.6.0",
+    "@data-fair/lib-node-registry": "^0.7.0",
     "config": "^4.4.1",
     "debug": "^4.4.1",
     "form-data": "^4.0.4",


### PR DESCRIPTION
Upgrade `@data-fair/lib-node-registry` 0.6.0 → 0.7.0 in `api` and `worker`,
and remove the now-redundant `cacheBust` option from `importPluginModule`.

**Why:** 0.7.0 extracts a changed artefact into a content-versioned directory,
so an updated plugin resolves to a brand-new absolute path. That forces Node's
ESM registry to reload the whole module graph (entry + siblings + bundled deps)
— something the old `?imported=<ts>` query suffix could never do (it only
reloaded the entry module). The query-string trick was also dead code: no caller
ever passed `cacheBust: true`.

**Regression risks:**
- `importPluginModule` lost its second `opts` parameter — a signature change on a
  shared export. All three callers (api, worker, the 0.11.0 upgrade script) pass
  a single argument; `check-types` passes.
- Plugin reload behavior changes at runtime: a long-running worker that previously
  could serve a stale module after a plugin update now reloads it. Intended, but
  the behavior shift is the point of the PR.
- On-disk registry cache layout changed; legacy `.meta.json` dirs are treated as
  cold and pruned by the lib, so no migration is required.
