### PR TITLE
fix: publication site selection and action label flicker

### DIFF
--- a/api/types/publication/schema.ts
+++ b/api/types/publication/schema.ts
@@ -165,7 +165,8 @@ export default {
           },
           itemsResults: 'data.publicationSites ?? []',
           itemValue: 'context.publicationSites[item]',
-          itemTitle: '`${context.publicationSites[item]?.title} (${context.publicationSites[item]?.url})`',
+          itemKey: 'item.url ?? context.publicationSites[item]?.url',
+          itemTitle: '`${item.title ?? context.publicationSites[item]?.title} (${item.url ?? context.publicationSites[item]?.url})`',
         },
         props: {
           noDataText: 'This dataset is not published on any site, you cannot publish it to a catalog.',

--- a/tests/features/publications/new-form.e2e.spec.ts
+++ b/tests/features/publications/new-form.e2e.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../../fixtures/login.ts'
+import { axiosAuth, cleanDb, cleanPlugins } from '../../support/axios.ts'
+import { publishMockPlugin } from '../../support/registry.ts'
+
+let catalogId: string
+
+test.describe('new publication form', () => {
+  test.beforeAll(async () => {
+    await cleanPlugins()
+    await publishMockPlugin()
+  })
+
+  test.beforeEach(async () => {
+    await cleanDb()
+    const ax = await axiosAuth('test_admin1@test.com')
+    const catalog = await ax.post('/api/catalogs', {
+      title: 'Test Catalog',
+      plugin: '@data-fair-catalog-mock-0',
+      owner: { type: 'user', id: 'test_admin1', name: 'test_admin1' },
+      config: { url: 'https://data.gouv.fr', delay: 0 }
+    })
+    catalogId = catalog.data._id
+  })
+
+  // the schema now waits for the plugin's i18n messages before it is built, so a plugin that
+  // never resolves its overrides must still let the form through rather than hang on an empty step
+  test('renders the configuration step', async ({ page, goToWithAuth }) => {
+    await goToWithAuth(`/catalogs/catalogs/${catalogId}/publications/new`, 'test_admin1')
+    await expect(page.getByLabel(/Jeu de données Data Fair/)).toBeVisible({ timeout: 15000 })
+  })
+})

--- a/tests/features/publications/publication-site-items.unit.spec.ts
+++ b/tests/features/publications/publication-site-items.unit.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { compile } from '@json-layout/core/compile'
+import { StatefulLayout } from '@json-layout/core/state'
+import jsonSchema from '@data-fair/lib-utils/json-schema.js'
+import { resolvedSchema } from '../../../api/types/publication/.type/index.js'
+
+// data-fair returns dataset.publicationSites as "<type>:<id>" keys, resolved against
+// the publicationSites context built by the new-publication page
+const publicationSites = {
+  'data-fair-portals:a': { title: 'Portail A', url: 'https://a.test', datasetUrlTemplate: 'https://a.test/d/{id}' },
+  'data-fair-portals:b': { title: 'Portail B', url: 'https://b.test', datasetUrlTemplate: 'https://b.test/d/{id}' }
+}
+
+const buildNode = async () => {
+  // mirrors the schema the new-publication page feeds to vjsf
+  const schema = jsonSchema(resolvedSchema).pickProperties(['dataFairDataset', 'publicationSite']).schema
+  const compiled = compile(schema)
+  const statefulLayout = new StatefulLayout(
+    compiled,
+    compiled.skeletonTrees[compiled.mainTree],
+    {
+      context: { origin: 'https://test.com', publicationSites },
+      fetch: async () => ({ publicationSites: Object.keys(publicationSites) })
+    },
+    { dataFairDataset: { id: 'ds1', title: 'DS 1' } }
+  )
+  const node = statefulLayout.stateTree.root.children!.find((c: any) => c.key === 'publicationSite')
+  const items = await statefulLayout.getItems(node)
+  return { statefulLayout, node, items }
+}
+
+test.describe('publicationSite getItems', () => {
+  test('gives each site a distinct scalar key', async () => {
+    const { items } = await buildNode()
+    const keys = items.map((i: any) => i.key)
+    expect(keys).toEqual(['https://a.test', 'https://b.test'])
+  })
+
+  // vjsf re-derives the key from the *resolved value* rather than the raw item
+  // (use-select-node.js valueComparator, use-get-items.js prepareSelectedItem), so the
+  // key must survive that round-trip. Without it every item collapses to the same key
+  // and vuetify treats them all as the current selection.
+  test('derives the same key from a raw item and from its resolved value', async () => {
+    const { statefulLayout, node, items } = await buildNode()
+    for (const item of items) {
+      expect(statefulLayout.prepareSelectItem(node, item.value).key).toBe(item.key)
+    }
+  })
+
+  test('keeps two selected sites distinguishable', async () => {
+    const { statefulLayout, node, items } = await buildNode()
+    const keyOf = (site: any) => statefulLayout.prepareSelectItem(node, site).key
+    expect(keyOf(items[0].value)).not.toBe(keyOf(items[1].value))
+  })
+
+  test('keeps the title readable once a site is selected', async () => {
+    const { statefulLayout, node, items } = await buildNode()
+    expect(statefulLayout.prepareSelectItem(node, items[0].value).title).toBe('Portail A (https://a.test)')
+  })
+})

--- a/ui/src/pages/catalogs/[catalogId]/publications/new.vue
+++ b/ui/src/pages/catalogs/[catalogId]/publications/new.vue
@@ -115,13 +115,17 @@ const router = useRouter()
 const session = useSessionAuthenticated()
 const datasetId = useStringSearchParam('datasetId')
 
-const { catalog, plugin } = createCatalogStore(route.params.catalogId)
+const { catalog, plugin, pluginFetch } = createCatalogStore(route.params.catalogId)
 
 const validPublicationConfig = ref(false)
 const selectedFolderOrResource = ref<{ id: string, title: string, type: 'resource' | 'folder' } | null>(null)
 const publicationConfig = ref<Partial<Pick<Publication, 'action' | 'dataFairDataset' | 'publicationSite' | 'remoteFolder' | 'remoteResource'>>>({})
-const defaultAction = ref<Publication['action'] | null>(null)
 const step = ref<'1' | '2'>('1')
+
+// the plugin can override the action labels through its own i18n messages, and vjsf rebuilds
+// its whole state tree whenever the schema changes identity. Building the schema before those
+// messages are merged would show the generic labels first, then swap them in a visible flicker.
+const pluginI18nSettled = ref(false)
 
 // Get datafair dataset info if datasetId is provided
 const dataFairDatasetFetch = useFetch<{ id: string; title: string }>(
@@ -147,23 +151,27 @@ const formattedPublicationSites = computed(() => {
   }, {})
 })
 
-const publicationSchema = computed(() => {
-  if (!catalog.value) return null
-
-  const availableActions = [
+const availableActions = computed(() => {
+  if (!catalog.value) return []
+  return [
     { title: t('actionLabels.createFolderInRoot'), value: 'createFolderInRoot' },
     { title: t('actionLabels.createFolder'), value: 'createFolder' },
     { title: t('actionLabels.createResource'), value: 'createResource' },
     { title: t('actionLabels.replaceFolder'), value: 'replaceFolder' },
     { title: t('actionLabels.replaceResource'), value: 'replaceResource' }
   ].filter(action => catalog.value?.capabilities.includes(action.value as Capability))
+})
+
+// a single available action is implicit, it is not offered as a form field
+const defaultAction = computed(() => availableActions.value.length === 1
+  ? availableActions.value[0].value as Publication['action']
+  : null)
+
+const publicationSchema = computed(() => {
+  if (!catalog.value || !pluginI18nSettled.value) return null
 
   const propertiesToPick = ['dataFairDataset']
-  if (availableActions.length > 1) {
-    propertiesToPick.push('action')
-  } else if (availableActions.length === 1) {
-    defaultAction.value = availableActions[0].value as Publication['action']
-  }
+  if (availableActions.value.length > 1) propertiesToPick.push('action')
 
   if (catalog.value.capabilities.includes('requiresPublicationSite')) {
     if (!publicationSites.data.value) return null
@@ -174,7 +182,7 @@ const publicationSchema = computed(() => {
     .pickProperties(propertiesToPick)
     .schema
 
-  if (base.properties.action) base.properties.action.layout.items = availableActions
+  if (base.properties.action) base.properties.action.layout.items = availableActions.value
   if (catalog.value.capabilities.includes('requiresPublicationSite')) base.required.push('publicationSite')
 
   return base
@@ -229,6 +237,12 @@ const handleNext = (next: () => void) => {
 watch(plugin, (newPlugin) => {
   if (!newPlugin) return
   if (newPlugin.metadata.i18n?.[session.lang.value]) mergeLocaleMessage(session.lang.value, newPlugin.metadata.i18n[session.lang.value])
+  pluginI18nSettled.value = true
+})
+
+// without a plugin there are no overrides to wait for, fall back to the generic labels
+watch(pluginFetch.error, (error) => {
+  if (error) pluginI18nSettled.value = true
 })
 
 watch(catalog, (newCatalog) => {


### PR DESCRIPTION
Two fixes to step 1 of the new publication form.

- **Publication site select** — the field defined `itemValue` but no `itemKey`, so the resolved object became the key. vjsf re-derives the key from that resolved value (`valueComparator`, `prepareSelectedItem`), and on that pass `context.publicationSites[item]` returns `undefined`: every item collapsed to the key `"undefined"`, the comparator reported them all equal to the current selection, and only the first option was ever selectable — the title collapsed to `"undefined (undefined)"` the same way. Both expressions now accept either the raw `"<type>:<id>"` string or the resolved object.
- **Action labels** — the plugin overrides `actionLabels` through its own i18n, merged once the plugin request resolves, after the catalog one. The schema computed reads `t()`, so that merge gave it a new identity, and vjsf rebuilds its whole state tree whenever the schema changes identity: the form appeared with the generic labels, then rebuilt with the plugin's. It now waits for the merge and is built once, already carrying the final labels. `defaultAction` also stopped being written from inside a computed.

**Why:** both reported on staging — only the first publication site was clickable, and the labels flickered between the generic and the plugin-overridden ones.

**Heads-up:**
- This predates the vuetify 4 migration: `valueComparator` and `prepareSelectItem` are identical in vjsf 3.26 / json-layout core 2.4, and the migration touched neither the page nor the schema.
- `itemKey` uses the site's `url` — the only field present both in the raw item and in the resolved object. Two publication sites sharing a URL would collide.
- Step 1 now waits for the plugin request before rendering: one extra round-trip of empty step instead of a flicker.
